### PR TITLE
Fix aria2 #code 22 error

### DIFF
--- a/Mooc/Mooc_Config.py
+++ b/Mooc/Mooc_Config.py
@@ -30,14 +30,14 @@ pause
 LENGTH = 80
 
 # 变量，可修改的参数
-download_speed = "1248K"
+download_speed = "12480K"
 if getattr(sys, 'frozen', False): #是否打包
     aria2_path = os.path.join(sys._MEIPASS, "aria2c.exe")
     alipay_path = os.path.join(sys._MEIPASS, "Alipay.jpg")
 else:
     aria2_path = os.path.join(PATH, "aria2c.exe")
     alipay_path = os.path.join(PATH, "Alipay.jpg")
-aira2_cmd = '%s -x 16 -s 64 -j 64 -k 2M --disk-cache 128M --max-overall-download-limit %s "{url:}" -d "{dirname:}" -o "{filename:}"'%(aria2_path, download_speed)
+aira2_cmd = '%s --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36 -- fUcIvJ01pZVQhNq23lXm9gjazkeonsCx" --check-certificate=false -x 16 -s 64 -j 64 -k 2M --disk-cache 128M --max-overall-download-limit %s "{url:}" -d "{dirname:}" -o "{filename:}"'%(aria2_path, download_speed)
 
 # 课程链接的正则匹配
 courses_re = {


### PR DESCRIPTION
Some guys were killed by the aria2 error(#code 22).
It may be caused by an ambiguous User-Agent. 